### PR TITLE
Add travis boilerplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+env:
+    - TOX_ENV=py27-1.7
+    - TOX_ENV=py27-1.8
+    - TOX_ENV=py27-1.9
+    - TOX_ENV=py34-1.7
+    - TOX_ENV=py34-1.8
+    - TOX_ENV=py34-1.9
+
+install:
+    - pip install tox --use-mirrors
+
+script:
+    - tox -e $TOX_ENV
+
+after_success:
+    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install coveralls --use-mirrors ; coveralls ; fi
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Build Status](https://travis-ci.org/lucaswiman/nonprimary-foreignkey.svg?branch=master)](https://travis-ci.org/lucaswiman/nonprimary-foreignkey)

--- a/nonprimary_foreignkey/tests/settings.py
+++ b/nonprimary_foreignkey/tests/settings.py
@@ -18,14 +18,26 @@ SECRET_KEY = 'secretkey'
 
 TEMPLATE_DIRS = (os.path.join(os.path.dirname(__file__), 'templates'),)
 
-DATABASES = {
-    'default': {
-        'NAME': 'nonprimary_foreignkey_test_db',
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'USER': 'django',
-        'PASSWORD': 'secret',
-    },
-}
+if 'TRAVIS' in os.environ:
+    DATABASES = {
+        'default': {
+            'ENGINE':   'django.db.backends.postgresql_psycopg2',
+            'NAME':     'travisci',
+            'USER':     'postgres',
+            'PASSWORD': '',
+            'HOST':     'localhost',
+            'PORT':     '',
+        }
+    }
+else:
+    DATABASES = {
+        'default': {
+            'NAME': 'nonprimary_foreignkey_test_db',
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'USER': 'django',
+            'PASSWORD': 'secret',
+        },
+    }
 
 ROOT_URLCONF = "nonprimary_foreignkey.tests.urls"
 

--- a/nonprimary_foreignkey/tests/settings.py
+++ b/nonprimary_foreignkey/tests/settings.py
@@ -1,4 +1,4 @@
-import os
+import os, re
 
 
 DEBUG = True
@@ -18,26 +18,20 @@ SECRET_KEY = 'secretkey'
 
 TEMPLATE_DIRS = (os.path.join(os.path.dirname(__file__), 'templates'),)
 
-if 'TRAVIS' in os.environ:
-    DATABASES = {
-        'default': {
-            'ENGINE':   'django.db.backends.postgresql_psycopg2',
-            'NAME':     'travisci',
-            'USER':     'postgres',
-            'PASSWORD': '',
-            'HOST':     'localhost',
-            'PORT':     '',
-        }
+# Namespace test database by the tox environment to allow detox to run tests
+# in parallel.
+_ENVNAME = re.sub(r'\W', '', os.environ.get("TOXENV", ""))
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'test%s.db' % _ENVNAME,
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
     }
-else:
-    DATABASES = {
-        'default': {
-            'NAME': 'nonprimary_foreignkey_test_db',
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'USER': 'django',
-            'PASSWORD': 'secret',
-        },
-    }
+}
 
 ROOT_URLCONF = "nonprimary_foreignkey.tests.urls"
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup
 from pip.req import parse_requirements
 from pip.download import PipSession
 
-from version import __version__
 
 
 def read_file(filename):
@@ -25,7 +24,6 @@ test_requirements = (
 
 setup(
     name='nonprimary-foreignkey',
-    version=__version__,
     author='Lucas Wiman',
     author_email='lucas.wiman@gmail.com',
     packages=['nonprimary_foreignkey'],

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,6 @@ envlist = {py27,py34}-{1.7,1.8,1.9}
 
 [testenv]
 usedevelop = True
-setenv =
-  XUNIT_FILE=nosetests-{envname}.xml
 commands =
   {envbindir}/coverage run -p --omit="*tests*" --source=nonprimary_foreignkey --branch \
     setup.py test
@@ -17,3 +15,5 @@ deps =
   1.7: Django>=1.7,<1.8
   1.8: Django>=1.8,<1.9
   1.9: Django>=1.9,<1.10
+setenv =
+  TOXENV={envname}


### PR DESCRIPTION
Adds boilerplate for travis-ci.org. This is only intended to test out travis.yml and see if it's working correctly.
