### PR TITLE
Implement field for handling non-primary foreign keys

### DIFF
--- a/nonprimary_foreignkey/fields.py
+++ b/nonprimary_foreignkey/fields.py
@@ -1,0 +1,80 @@
+import django
+from django.core import checks
+
+if django.VERSION < (1, 8):
+    from django.db.models.loading import get_model
+else:
+    from django.apps import apps
+    get_model = apps.get_model
+
+
+class NonPrimaryForeignKey(object):
+    """
+    Descriptor class for handling non-primary foreign keys.
+
+    The implementation is loosely based on ``GenericForeignKey`` from the
+    ``django.contrib.contenttypes`` module.
+    """
+
+    def __init__(self, to_model, from_field, to_field):
+        self._to_model = to_model
+        self.from_field = from_field
+        self.to_field = to_field
+        self.editable = False
+
+    @property
+    def to_model(self):
+        return get_model(self._to_model)
+
+    def contribute_to_class(self, cls, name):
+        self.name = name
+        self.model = cls
+        self.cache_attr = "_%s_cache" % name
+        setattr(cls, name, self)
+
+    def __get__(self, instance, instance_type=None):
+        if instance is None:
+            return self
+
+        try:
+            return getattr(instance, self.cache_attr)
+        except AttributeError:
+            rel_obj = None
+            f = self.model._meta.get_field(self.from_field)
+            value = getattr(instance, f.get_attname(), None)
+            if value is None:
+                return None
+            rel_obj = self.to_model._default_manager.get(
+                **{self.to_field: value})
+            setattr(instance, self.cache_attr, rel_obj)
+            return rel_obj
+
+    def __set__(self, instance, value):
+        if not (value is None or isinstance(value, self.to_model)):
+            raise TypeError('%r must is not a %s' % (value, self.to_model))
+        to_f = self.to_model._meta.get_field(self.to_field)
+        f = self.model._meta.get_field(self.from_field)
+        set_value = getattr(value, to_f.get_attname(), None)
+        setattr(instance, self.cache_attr, value)
+        setattr(instance, f.get_attname(), set_value)
+
+    def __str__(self):
+        model = self.model
+        app = model._meta.app_label
+        return '%s.%s.%s' % (app, model._meta.object_name, self.name)
+
+    def check(self, **kwargs):
+        errors = []
+        if self.name.endswith("_"):
+            errors.append(
+                checks.Error(
+                    'Field names must not end with an underscore.',
+                    hint=None,
+                    obj=self,
+                    id='fields.E001',
+                )
+            )
+        return errors
+
+    def get_prefetch_queryset(self, instances, queryset=None):
+        raise NotImplementedError()

--- a/nonprimary_foreignkey/fields.py
+++ b/nonprimary_foreignkey/fields.py
@@ -51,13 +51,10 @@ class NonPrimaryForeignKey(object):
         value = getattr(instance, self.from_field.attname, None)
         if value is None:
             return None
-        try:
-            cached = getattr(instance, self.cache_name)
-        except AttributeError:
-            cached = UNDEFINED
-        if cached is not UNDEFINED:
-            if getattr(cached, self.to_field.attname, None) == value:
-                return cached
+        cached = getattr(instance, self.cache_name, UNDEFINED)
+
+        if cached is not UNDEFINED and getattr(cached, self.to_field.attname, None) == value:
+            return cached
 
         rel_obj = None
         rel_obj = self.to_model._default_manager.get(

--- a/nonprimary_foreignkey/fields.py
+++ b/nonprimary_foreignkey/fields.py
@@ -103,8 +103,9 @@ class NonPrimaryForeignKey(object):
         values = [
             getattr(instance, self.from_field.attname, None) for instance in instances
             if getattr(instance, self.from_field.attname, None) is not None]
-        queryset = (queryset or self.to_model._default_manager).filter(**{
-            '%s__in' % self.to_field.attname: values})
+        if queryset is None:
+            queryset = self.to_model._default_manager
+        queryset = queryset.filter(**{'%s__in' % self.to_field.attname: values})
         rel_obj_attr = lambda rel_obj: (getattr(rel_obj, self.to_field.attname), )
         instance_attr = lambda obj: (getattr(obj, self.from_field.attname), )
         return queryset, rel_obj_attr, instance_attr, True, self.cache_name

--- a/nonprimary_foreignkey/fields.py
+++ b/nonprimary_foreignkey/fields.py
@@ -35,7 +35,6 @@ class NonPrimaryForeignKey(object):
     def __get__(self, instance, instance_type=None):
         if instance is None:
             return self
-
         try:
             return getattr(instance, self.cache_name)
         except AttributeError:

--- a/nonprimary_foreignkey/fields.py
+++ b/nonprimary_foreignkey/fields.py
@@ -20,10 +20,10 @@ class NonPrimaryForeignKey(object):
     ``django.contrib.contenttypes`` module.
     """
 
-    def __init__(self, to_model, from_field, to_field):
+    def __init__(self, to_model, from_field, to_field=None):
         self._to_model = to_model
         self._from_field = from_field
-        self._to_field = to_field
+        self._to_field = to_field or from_field  # Default to the fields sharing a name.
         self.editable = False
 
     @cached_property

--- a/nonprimary_foreignkey/tests/models.py
+++ b/nonprimary_foreignkey/tests/models.py
@@ -1,0 +1,12 @@
+from django.db import models
+
+from nonprimary_foreignkey.fields import NonPrimaryForeignKey
+
+
+class Item(models.Model):
+    barcode = models.CharField(null=False, max_length=100)
+
+
+class ReceivedItem(models.Model):
+    barcode = models.CharField(null=True, max_length=100)
+    item = NonPrimaryForeignKey('tests.Item', 'barcode', 'barcode')

--- a/nonprimary_foreignkey/tests/models.py
+++ b/nonprimary_foreignkey/tests/models.py
@@ -3,8 +3,13 @@ from django.db import models
 from nonprimary_foreignkey.fields import NonPrimaryForeignKey
 
 
+class ItemType(models.Model):
+    pass
+
+
 class Item(models.Model):
     barcode = models.CharField(null=False, max_length=100)
+    item_type = models.ForeignKey(ItemType, null=True, default=None)
 
     def __repr__(self):
         return 'Item(barcode=%r)' % self.barcode
@@ -13,3 +18,7 @@ class Item(models.Model):
 class ReceivedItem(models.Model):
     barcode = models.CharField(null=True, max_length=100)
     item = NonPrimaryForeignKey('tests.Item', 'barcode', 'barcode')
+
+
+class RelatedItem(models.Model):
+    item = models.ForeignKey(Item)

--- a/nonprimary_foreignkey/tests/models.py
+++ b/nonprimary_foreignkey/tests/models.py
@@ -6,6 +6,9 @@ from nonprimary_foreignkey.fields import NonPrimaryForeignKey
 class Item(models.Model):
     barcode = models.CharField(null=False, max_length=100)
 
+    def __repr__(self):
+        return 'Item(barcode=%r)' % self.barcode
+
 
 class ReceivedItem(models.Model):
     barcode = models.CharField(null=True, max_length=100)

--- a/nonprimary_foreignkey/tests/settings.py
+++ b/nonprimary_foreignkey/tests/settings.py
@@ -6,7 +6,6 @@ DEBUG = True
 
 INSTALLED_APPS = (
     'nonprimary_foreignkey.tests',
-    'nonprimary_foreignkey',
     'django_nose',
     'django.contrib.staticfiles',
     'django.contrib.sessions',

--- a/nonprimary_foreignkey/tests/tests.py
+++ b/nonprimary_foreignkey/tests/tests.py
@@ -78,3 +78,16 @@ class TestPrefetch(TestCase):
             self.assertEqual(len(queryset), 2)
         with self.assertNumQueries(0):
             self.assertEqual({obj.item for obj in queryset}, {self.item1, self.item2})
+
+    def test_null(self):
+        self.assertEqual(
+            ReceivedItem.objects.create(barcode=None).item,
+            None)
+        self.assertEqual(
+            ReceivedItem.objects.create(barcode=self.barcode1).item,
+            self.item1)
+        with self.assertNumQueries(2):
+            queryset = ReceivedItem.objects.prefetch_related('item')
+            self.assertEqual(len(queryset), 2)
+        with self.assertNumQueries(0):
+            self.assertEqual({obj.item for obj in queryset}, {self.item1, None})

--- a/nonprimary_foreignkey/tests/tests.py
+++ b/nonprimary_foreignkey/tests/tests.py
@@ -2,6 +2,7 @@ from django.db.models import Prefetch
 from django.test.testcases import TestCase
 from mock import patch
 
+from nonprimary_foreignkey.fields import NonPrimaryForeignKey
 from nonprimary_foreignkey.tests.models import Item
 from nonprimary_foreignkey.tests.models import ItemType
 from nonprimary_foreignkey.tests.models import ReceivedItem
@@ -172,3 +173,7 @@ class TestMisc(TestCase):
         self.assertEqual(ReceivedItem.item.check(), [])
         with patch.object(ReceivedItem.item, 'name', 'foo_'):
             self.assertEqual(len(ReceivedItem.item.check()), 1)
+
+    def test_empty_to_field_default(self):
+        descriptor = NonPrimaryForeignKey('tests.Item', 'barcode')
+        self.assertEqual(descriptor.to_field.attname, 'barcode')

--- a/nonprimary_foreignkey/tests/tests.py
+++ b/nonprimary_foreignkey/tests/tests.py
@@ -1,0 +1,55 @@
+from django.test.testcases import TestCase
+from nonprimary_foreignkey.tests.models import Item
+from nonprimary_foreignkey.tests.models import ReceivedItem
+
+
+class TestGet(TestCase):
+    def setUp(self):
+        Item.objects.all().delete()
+        self.barcode = '12345'
+        self.item = Item.objects.create(barcode=self.barcode)
+
+    def test_get(self):
+        from_instance = ReceivedItem.objects.create()
+        from_instance.barcode = self.barcode
+        self.assertEqual(from_instance.item, self.item)
+
+    def test_get_non_existent_barcode(self):
+        from_instance = ReceivedItem.objects.create()
+        from_instance.barcode = 'not a barcode'
+        with self.assertRaises(Item.DoesNotExist):
+            from_instance.item
+
+    def test_get_multiple_objects(self):
+        Item.objects.create(barcode=self.barcode)
+        from_instance = ReceivedItem.objects.create()
+        from_instance.barcode = self.barcode
+        with self.assertRaises(Item.MultipleObjectsReturned):
+            from_instance.item
+
+
+class TestSet(TestCase):
+    def setUp(self):
+        Item.objects.all().delete()
+        self.barcode = '12345'
+        self.item = Item.objects.create(barcode=self.barcode)
+
+    def test_set(self):
+        from_instance = ReceivedItem.objects.create()
+        from_instance.item = self.item
+        self.assertEqual(from_instance.item, self.item)
+        self.assertEqual(from_instance.barcode, self.barcode)
+
+    def test_set_null(self):
+        from_instance = ReceivedItem.objects.create()
+        from_instance.item = self.item
+        self.assertEqual(from_instance.item, self.item)
+        self.assertEqual(from_instance.barcode, self.barcode)
+        from_instance.item = None
+        self.assertEqual(from_instance.item, None)
+        self.assertEqual(from_instance.barcode, None)
+
+    def test_set_underlying_field_null(self):
+        from_instance = ReceivedItem.objects.create()
+        self.assertEqual(from_instance.barcode, None)
+        self.assertEqual(from_instance.item, None)

--- a/nonprimary_foreignkey/tests/tests.py
+++ b/nonprimary_foreignkey/tests/tests.py
@@ -100,6 +100,17 @@ class TestPrefetch(TestCase):
         with self.assertNumQueries(0):
             self.assertEqual({obj.item for obj in queryset}, {self.item1, None})
 
+    def test_set_with_prefetched_object(self):
+        self.assertEqual(
+            ReceivedItem.objects.create(barcode=self.barcode1).item,
+            self.item1)
+        [item] = ReceivedItem.objects.prefetch_related('item').all()
+        with self.assertNumQueries(0):
+            self.assertEqual(item.item, self.item1)
+        with self.assertNumQueries(1):
+            item.barcode = self.item2.barcode
+            self.assertEqual(item.item, self.item2)
+
 
 class TestMisc(TestCase):
     def test_str(self):

--- a/nonprimary_foreignkey/tests/tests.py
+++ b/nonprimary_foreignkey/tests/tests.py
@@ -53,3 +53,28 @@ class TestSet(TestCase):
         from_instance = ReceivedItem.objects.create()
         self.assertEqual(from_instance.barcode, None)
         self.assertEqual(from_instance.item, None)
+
+
+class TestPrefetch(TestCase):
+    def setUp(self):
+        Item.objects.all().delete()
+        self.barcode1 = '12345'
+        self.item1 = Item.objects.create(barcode=self.barcode1)
+        self.barcode2 = '67890'
+        self.item2 = Item.objects.create(barcode=self.barcode2)
+
+    def test_constant_queries(self):
+        self.assertEqual(
+            ReceivedItem.objects.create(barcode=self.barcode1).item,
+            self.item1)
+        self.assertEqual(
+            ReceivedItem.objects.create(barcode=self.barcode2).item,
+            self.item2)
+        with self.assertNumQueries(1):
+            self.assertEqual(len(ReceivedItem.objects.all()), 2)
+        # Prefetching should include the query to grab the related ``Item`` objects.
+        with self.assertNumQueries(2):
+            queryset = ReceivedItem.objects.prefetch_related('item')
+            self.assertEqual(len(queryset), 2)
+        with self.assertNumQueries(0):
+            self.assertEqual({obj.item for obj in queryset}, {self.item1, self.item2})

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [flake8]
+ignore=E731
 exclude = migrations
 max-line-length = 100
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [flake8]
-exclude = migrations,south_migrations
+exclude = migrations
+max-line-length = 100
 
 [tox]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
This PR introduces a descriptor for Django models that supports foreign-key-like operations on non-primary fields. The intended use case is for models which have some field which uniquely identifies it, but may not be the primary key of the model. Relational databases support this use case well, but Django seems to have completely ignored it.

Django also doesn't support non-integer primary keys very well for any models which need to interact with the `contrib.contenttypes` framework, which means some "natural" identifiers, like a barcode or UUID are not suitable as a primary key in a django application.
## Implementation details

The key methods to implement are the standard python descriptor fields `__get__` and `__set__`, as well as `get_prefetch_queryset`. The latter method allows maintaining a constant number of queries in bulk operations and list views by calling `QuerySet.prefetch_related`. The implementation is based on `GenericForeignKey` and the confusingly-named `ReverseSingleRelatedObjectDescriptor` used by `ForeignKey`.

The test suite runs on Django 1.7-1.9, as well as Python 2.7 and 3.4.

cc @cmason1978
